### PR TITLE
Fix bug where we cycle through an endless loop

### DIFF
--- a/autoload/mucomplete.vim
+++ b/autoload/mucomplete.vim
@@ -149,9 +149,9 @@ fun! s:next_method()
     let s:i = (s:cycle ? (s:i + s:dir + s:N) % s:N : s:i + s:dir)
   endwhile
   if (s:i+1) % (s:N+1) != 0 && index(s:i_history, s:i) == -1
-      if s:cycle
-          let s:i_history += [s:i]
-      endif
+    if s:cycle
+      let s:i_history += [s:i]
+    endif
     return s:compl_mappings[s:compl_methods[s:i]] . "\<c-r>\<c-r>=pumvisible()?mucomplete#yup():''\<cr>\<plug>(MUcompleteNxt)"
   endif
   return ''

--- a/autoload/mucomplete.vim
+++ b/autoload/mucomplete.vim
@@ -38,6 +38,7 @@ let s:auto = 0
 let s:dir = 1
 let s:cycle = 0
 let s:i = 0
+let s:i_history = []
 let s:pumvisible = 0
 
 if exists('##TextChangedI') && exists('##CompleteDone')
@@ -147,7 +148,10 @@ fun! s:next_method()
   while (s:i+1) % (s:N+1) != 0  && !s:can_complete()
     let s:i = (s:cycle ? (s:i + s:dir + s:N) % s:N : s:i + s:dir)
   endwhile
-  if (s:i+1) % (s:N+1) != 0
+  if (s:i+1) % (s:N+1) != 0 && index(s:i_history, s:i) == -1
+      if s:cycle
+          let s:i_history += [s:i]
+      endif
     return s:compl_mappings[s:compl_methods[s:i]] . "\<c-r>\<c-r>=pumvisible()?mucomplete#yup():''\<cr>\<plug>(MUcompleteNxt)"
   endif
   return ''
@@ -159,7 +163,7 @@ endf
 
 " Precondition: pumvisible() is true.
 fun! mucomplete#cycle(dir)
-  let [s:dir, s:cycle] = [a:dir, 1]
+  let [s:dir, s:cycle, s:i_history] = [a:dir, 1, []]
   return "\<c-e>" . s:next_method()
 endf
 
@@ -181,6 +185,7 @@ fun! mucomplete#complete(dir)
         \ get(g:mucomplete#chains, getbufvar("%", "&ft"), g:mucomplete#chains['default']))
   let s:N = len(s:compl_methods)
   let s:i = s:dir > 0 ? -1 : s:N
+  let s:i_history = []
   return s:next_method()
 endf
 


### PR DESCRIPTION
Hello,

it's not frequent, but sometimes when I try to cycle in the completion chain, the plugin seems to get stuck in a loop. The cpu load gets high, and Vim doesn't respond anymore. It's possible that the bug occurs only if the size of the terminal window and / or font have specific values, so I don't know if the following will reproduce the bug on your system, but it does on mine.

If I write this in `/tmp/vimrc.vim`:
```

set cot=menuone
set rtp+=~/.vim/plugged/vim-mucomplete
setlocal tw=78

"    xx                                                  zzz
" zzzyyyyyyyyyyyyyyyyyyy
```

And then, if I launch Vim like this:

    $ vim -Nu /tmp/vimrc.vim /tmp/vimrc.vim

Place the cursor after `zzz`, hit Tab to complete, then `C-l` to move forward in the chain, the bug occurs.

I think the problem comes from the fact that `s:next_method()` fails to see that the popup menu is visible.
Maybe because in this particular configuration, the menu can't be opened, or because there's some delay.
Therefore, the variable `s:pumvisible` is not set properly.

After hitting the completion mappings, and incorrectly set the `s:pumvisible` variable, `s:next_method()` hit `<plug>(MC_next_method)`, which calls `verify_completion()`.
The latter relies on `s:pumvisible` to decide whether it should call `act_on_pumvisible()` or try another method and recall `s:next_method()`.

The endless loop can be observed by creating global variables at various places in `s:next_method()`, then triggering the bug, and finally echo their values.
For example, assuming we use this chain:

        let g:mucomplete#chains = {}
        let g:mucomplete#chains.default = ['file', 'omni', 'keyn', 'dict', 'spel', 'path', 'ulti']

… if we add the line:

        let g:idx_list   = get(g:, 'idx_list', []) + [s:i]

… just after:

        let s:i = (s:i + s:dir + s:N) % s:N

When we echo `g:idx_list`, we get a big list of 3's (`[3, 3, 3, …]`).

If we add the line:

        let g:idx_list   = get(g:, 'idx_list', []) + [s:i]

… just after (`s:cycle` is set to 1):

        let s:i = (s:i + s:dir + s:N) % s:N

When we echo `g:idx_list`, we get a circular list:

        [4, 5, 6, 0, 1, 2, 4, 5, 6, 0, 1, 2, …]

If we add the line:

        let g:idx_list   = get(g:, 'idx_list', []) + [s:i]

… just after the while loop, when we echo `g:idx_list`, we get a big list of 2's (`[2, 2, 2, …]`).

Which shows that each time `s:next_method()` is called, it finds the same next method, n°2.

To prevent this, before hitting the completion mappings, we could ask `s:next_method()` to check whether the next method is different than the current one.
To do so, we can store the current index in a variable at the beginning of the function:

        let old_i = s:i

Then, add to the test:

        if (s:i+1) % (s:N+1) != 0

… (which conditions whether the completion mappings will be hit), the following statement:

        … && s:i != old_i

There's still a problem, that I haven't encountered yet though.
Maybe in some particular circumstances, we could get stuck in a different kind of loop…
Imagine, `s:next_method()` finds that the next method to try is `2`. It tries it, but it fails. So, `s:next_method()` is recalled.
This time, it finds that the next method to try is `4`. It tries it, but it fails. So, `s:next_method()` is recalled.
This time, it finds that the next method is, again, `2`.

At this moment, we could be entering a loop from which we couldn't get out, even with the `old_i` variable.

I've been thinking at a more robust solution to this problem. When `s:cycle` is set to 1, maybe we should create a variable (`s:i_history`), in which we would store all the indexes of the methods tried. Inside `s:next_method()`, before hitting a completion mapping, we would make sure that the index of the method we're going to try is not in this list.

This should prevent any kind of spurious loop.
Finally, inside `cycle()` and `complete()`, we would empty the list, so that the methods whose indexes are in this temporary list could be tested again, the next time we would ask for a completion via Tab or via cycling (C-h, C-l).