### PR TITLE
Fix ulti method

### DIFF
--- a/autoload/mucomplete/ultisnips.vim
+++ b/autoload/mucomplete/ultisnips.vim
@@ -5,7 +5,7 @@
 let s:save_cpo = &cpo
 set cpo&vim
 
-let s:cmp = 'stridx(l:pat, v:val)' . (get(g:, 'mucomplete#ultisnips#match_at_start', 1) ? '==0' : '>=0')
+let s:cmp = 'stridx(v:val, l:pat)' . (get(g:, 'mucomplete#ultisnips#match_at_start', 1) ? '==0' : '>=0')
 
 fun! mucomplete#ultisnips#complete() abort
   if empty(UltiSnips#SnippetsInCurrentScope(1))


### PR DESCRIPTION
Hello,

In the `ulti` method, I think a regression was introduced [here](https://github.com/lifepillar/vim-mucomplete/issues/28).

Because, the order of the arguments passed to `stridx()` was inverted, which seems to prevent the `ulti` method to function properly.

For example, I have the following snippet definition:
```
snippet op "Custom Operator" bm
nno <silent> ${1:key}     :<C-U>set opfunc=${2:function name}<CR>g@
nno <silent> $1${1/.(.*)/$1/}    :<C-U>set opfunc=$2<Bar>exe 'norm! ' . v:count1 . 'g@_'<CR>
xno <silent> $1     :<C-U>call $2(visualmode(), 1)<CR>
```

… whose tab trigger is `op`.

If I use this configuration:

```
let g:mucomplete#chains = {}
let g:mucomplete#chains.default = ['ulti']
```

And if I insert the character `o` then Tab, the plugin doesn't suggest `op`.
After inverting the order of the arguments, the method seems to work properly again.

Thank you for your plugin and for reading my PR.
