### PR TITLE
Abbrev method

### DIFF
--- a/autoload/mucomplete.vim
+++ b/autoload/mucomplete.vim
@@ -17,6 +17,7 @@ set cpo&vim
 
 let s:cnp = "\<c-x>" . get(g:, 'mucomplete#exit_ctrlx_keys', "\<c-b>\<bs>")
 let s:compl_mappings = extend({
+      \ 'abbr': "\<c-r>=mucomplete#abbr#complete()\<cr>",
       \ 'c-n' : s:cnp."\<c-n>", 'c-p' : s:cnp."\<c-p>",
       \ 'cmd' : "\<c-x>\<c-v>", 'defs': "\<c-x>\<c-d>",
       \ 'dict': "\<c-x>\<c-k>", 'file': "\<c-x>\<c-f>",

--- a/autoload/mucomplete/abbr.vim
+++ b/autoload/mucomplete/abbr.vim
@@ -5,7 +5,12 @@
 let s:save_cpo = &cpo
 set cpo&vim
 
-let s:abbrev = map(reverse(split(execute('iabbrev'), "\n")), '{
+let s:suggestions = ''
+redir => s:suggestions
+silent iabbrev
+redir END
+
+let s:abbrev = map(reverse(split(s:suggestions, "\n")), '{
       \ "lhs" : matchstr(v:val, "\\mi\\s\\+\\zs\\k\\+"),
       \ "rhs" : matchstr(v:val, "\\m\\*\\s\\+\\zs.*"),
       \ }')

--- a/autoload/mucomplete/abbr.vim
+++ b/autoload/mucomplete/abbr.vim
@@ -1,0 +1,27 @@
+" Chained completion that works as I want!
+" Maintainer: Lifepillar <lifepillar@lifepillar.me>
+" License: This file is placed in the public domain
+
+let s:save_cpo = &cpo
+set cpo&vim
+
+let s:abbrev = map(reverse(split(execute('iabbrev'), "\n")), '{
+      \ "lhs" : matchstr(v:val, "\\mi\\s\\+\\zs\\k\\+"),
+      \ "rhs" : matchstr(v:val, "\\m\\*\\s\\+\\zs.*"),
+      \ }')
+
+fun! mucomplete#abbr#complete() abort
+  let l:word = matchstr(strpart(getline('.'), 0, col('.') - 1), '\S\+$')
+  let l:abbrev = map(filter(copy(s:abbrev), 'stridx(v:val.lhs, l:word) == 0'),
+        \ '{ "word" : v:val.lhs,
+        \    "menu" : v:val.rhs,
+        \ }')
+  let g:abbrev = l:abbrev
+  if !empty(l:abbrev)
+    call complete(col('.') - len(l:word), l:abbrev)
+  endif
+  return ''
+endf
+
+let &cpo = s:save_cpo
+unlet s:save_cpo

--- a/autoload/mucomplete/abbr.vim
+++ b/autoload/mucomplete/abbr.vim
@@ -16,7 +16,6 @@ fun! mucomplete#abbr#complete() abort
         \ '{ "word" : v:val.lhs,
         \    "menu" : v:val.rhs,
         \ }')
-  let g:abbrev = l:abbrev
   if !empty(l:abbrev)
     call complete(col('.') - len(l:word), l:abbrev)
   endif

--- a/autoload/mucomplete/abbr.vim
+++ b/autoload/mucomplete/abbr.vim
@@ -5,12 +5,12 @@
 let s:save_cpo = &cpo
 set cpo&vim
 
-let s:suggestions = ''
-redir => s:suggestions
+let s:abbrev = ''
+redir => s:abbrev
 silent iabbrev
 redir END
 
-let s:abbrev = map(reverse(split(s:suggestions, "\n")), '{
+let s:abbrev = map(reverse(split(s:abbrev, "\n")), '{
       \ "lhs" : matchstr(v:val, "\\mi\\s\\+\\zs\\k\\+"),
       \ "rhs" : matchstr(v:val, "\\m\\*\\s\\+\\zs.*"),
       \ }')


### PR DESCRIPTION
Hello,

since the plugin already implements custom methods like `path`, `spel` and `ulti`, I thought it could be useful to add an `abbr` method which suggests abbreviations for the word before the cursor.