### PR TITLE
Refactor uspl method

### DIFF
--- a/autoload/mucomplete.vim
+++ b/autoload/mucomplete.vim
@@ -26,7 +26,7 @@ let s:compl_mappings = extend({
       \ 'tags': "\<c-x>\<c-]>", 'thes': "\<c-x>\<c-t>",
       \ 'user': "\<c-x>\<c-u>", 'ulti': "\<c-r>=mucomplete#ultisnips#complete()\<cr>",
       \ 'path': "\<c-r>=mucomplete#path#complete()\<cr>",
-      \ 'uspl': "\<c-o>:call mucomplete#spel#gather()\<cr>\<c-r>=mucomplete#spel#complete()\<cr>"
+      \ 'uspl': "\<c-r>=mucomplete#spel#complete()\<cr>"
       \ }, get(g:, 'mucomplete#user_mappings', {}), 'error')
 unlet s:cnp
 let s:select_entry = { 'c-p' : "\<c-p>\<down>", 'keyp': "\<c-p>\<down>" }

--- a/autoload/mucomplete/spel.vim
+++ b/autoload/mucomplete/spel.vim
@@ -6,14 +6,14 @@ let s:save_cpo = &cpo
 set cpo&vim
 
 fun! mucomplete#spel#complete() abort
-  let l:word        = matchstr(getline('.'), '\S\+\%'.col('.').'c')
-  let l:badword     = spellbadword(l:word)
+  let l:col         = 1 + match(strpart(getline('.'), 0, col('.') - 1), '\S\+$')
+  let l:badword     = spellbadword(matchstr(getline('.'), '\S\+\%'.col('.').'c'))
   let l:suggestions = !empty(l:badword[1])
                     \ ? spellsuggest(l:badword[0])
                     \ : []
 
   if !empty(l:suggestions)
-    call complete(col('.') - len(l:word), l:suggestions)
+    call complete(l:col, l:suggestions)
   endif
   return ''
 endf

--- a/autoload/mucomplete/spel.vim
+++ b/autoload/mucomplete/spel.vim
@@ -5,19 +5,15 @@
 let s:save_cpo = &cpo
 set cpo&vim
 
-let s:suggestions = ''
-
-fun! mucomplete#spel#gather() abort
-  redir => s:suggestions
-  silent normal! z=
-  redir END
-endf
-
 fun! mucomplete#spel#complete() abort
-  let l:col = 1 + match(strpart(getline('.'), 0, col('.') - 1), '\S\+$')
-  let l:suggestions = map(filter(split(s:suggestions, "\n"), 'v:val =~# "\\m^\\s*\\d"'), "matchstr(v:val, '\"\\zs.\\+\\ze\"')")
+  let l:word        = matchstr(getline('.'), '\S\+\%'.col('.').'c')
+  let l:badword     = spellbadword(l:word)
+  let l:suggestions = !empty(l:badword[1])
+                    \ ? spellsuggest(l:badword[0])
+                    \ : []
+
   if !empty(l:suggestions)
-    call complete(l:col, l:suggestions)
+    call complete(col('.') - len(l:word), l:suggestions)
   endif
   return ''
 endf


### PR DESCRIPTION
Hello,

If I use the following configuration:

```
let g:mucomplete#chains = {}
let g:mucomplete#chains.default = ['uspl']
```

… and I have the following text:

`helzo| people`

… the cursor being represented by the pipe, and I hit Tab to fix `helzo` into `hello`, the current `uspl` method tries to fix `people` instead of `helzo`.

It's probably an edge case, because most of the time, when we try to fix a word in insert mode, we are probably at the end of the line, but I think the problem comes from the `:normal` command.

We could get rid of it, as well as the `gather()` function, and use the built-in functions `spellbadword()` and `spellsuggest()` instead. It would also fix the edge case described earlier.