### PR TITLE
Fix inconsistent behavior of the `cmd` method

### DIFF
--- a/autoload/mucomplete.vim
+++ b/autoload/mucomplete.vim
@@ -168,7 +168,12 @@ fun! s:next_method_cyclic()
 endf
 
 fun! mucomplete#verify_completion()
-  return s:pumvisible ? s:act_on_pumvisible() : (s:cycle ? s:next_method_cyclic() : s:next_method())
+  return s:pumvisible
+            \ ? s:act_on_pumvisible()
+            \ : (s:compl_methods[s:i] ==# 'cmd'
+            \   ? get(g:, 'mucomplete#ctrlx_mode_out', "\<c-g>\<c-g>")
+            \   : '')
+            \   . (s:cycle ? s:next_method_cyclic() : s:next_method())
 endf
 
 " Precondition: pumvisible() is true.


### PR DESCRIPTION
Hello,

this is an attempt at fixing the inconsistent behavior of the `cmd` method discussed in this [issue](https://github.com/lifepillar/vim-mucomplete/issues/42).

I don't know whether you will want to make the code more complex only for this issue, I just thought it could help.