### PR TITLE
Select first result with tab_complete only if 'completeopt' doesn't have 'noselect'

### DIFF
--- a/autoload/mucomplete.vim
+++ b/autoload/mucomplete.vim
@@ -239,7 +239,7 @@ fun! mucomplete#tab_complete(dir)
   else
     let s:compl_text = matchstr(getline('.'), '\S\+\%'.col('.').'c')
     if get(b:, 'mucomplete_empty_text', get(g:, 'mucomplete#empty_text', 0)) || !empty(s:compl_text)
-      call mucomplete#init(a:dir, 1)
+      call mucomplete#init(a:dir, match(&completeopt, '\<noselect\>') > -1 ? 0 : 1)
       return s:next_method()
     endif
     return (a:dir > 0 ? "\<plug>(MUcompleteTab)" : "\<plug>(MUcompleteCtd)")


### PR DESCRIPTION
Through these changes, the behaviour of the manual completion (with `<tab>` by default) will be consistent with that of the autocomplete when `completeopt` has the `noselect` option activated.

This way, if `completeopt` has `noselect`, when the user presses `<tab>`, the pum with completion results should be shown, but the first result should not be selected; but only when the user presses `<tab>/<s-tab>` again (or his/her shortcut for forward/backward) will the first/last result be selected.