### PR TITLE
g:mucomplete#scoped_chains

### DIFF
--- a/doc/mucomplete.txt
+++ b/doc/mucomplete.txt
@@ -435,7 +435,6 @@ variable is defined, the value of |g:mucomplete#chains| is ignored.
 
 
 					*'g:mucomplete#chains'*
-					*'g:mucomplete#scoped_chains'*
 A Dictionary defining the Lists of completion chains.
 >
 	let g:mucomplete#chains = {
@@ -450,19 +449,21 @@ completion chains. For example:
 	let g:mucomplete#chains.default  = ['omni', 'c-p']
 	let g:mucomplete#chains.markdown = ['keyn', 'dict', 'uspl']
 <
-An additional dictionary defines chains that will be active inside certain
-syntax elements ('scopes'), and in a certain filetype. If you don't define
-this dictionary, or the current filetype and scope inside of it, other defined
-chains will be used. If all of the above is defined, the scoped chain will be
-used instead, if the current syntax element matches one that have been
-defined. If you define a chain, but set it empty, it means you don't want any
-kind of completion inside that scope. In this case, completion will fallback
-to use 'path' completion as a bare minimum.
+					*'g:mucomplete#scoped_chains'*
+A Dictionary defining chains that will be active inside certain syntax
+elements ('scopes'), and in certain filetypes.
 
 Default:
 >
 	let g:mucomplete#scoped_chains = {}
 <
+If you don't define this dictionary, it will be ignored. Otherwise mucomplete
+will look for the current filetype and scope inside of it, and will use it if
+the current scope matches one that has been defined. 
+If you define a chain, but set it empty, it means you don't want any kind of
+completion inside that scope. In this case, completion will fallback to use
+'path' completion.
+
 Example:
 >
 	let g:mucomplete#scoped_chains = {

--- a/doc/mucomplete.txt
+++ b/doc/mucomplete.txt
@@ -435,6 +435,7 @@ variable is defined, the value of |g:mucomplete#chains| is ignored.
 
 
 					*'g:mucomplete#chains'*
+					*'g:mucomplete#scoped_chains'*
 A Dictionary defining the Lists of completion chains.
 >
 	let g:mucomplete#chains = {
@@ -448,6 +449,27 @@ completion chains. For example:
 	let g:mucomplete#chains = {}
 	let g:mucomplete#chains.default  = ['omni', 'c-p']
 	let g:mucomplete#chains.markdown = ['keyn', 'dict', 'uspl']
+<
+An additional dictionary defines chains that will be active inside certain
+syntax elements ('scopes'), and in a certain filetype. If you don't define
+this dictionary, or the current filetype and scope inside of it, other defined
+chains will be used. If all of the above is defined, the scoped chain will be
+used instead, if the current syntax element matches one that have been
+defined. If you define a chain, but set it empty, it means you don't want any
+kind of completion inside that scope. In this case, completion will fallback
+to use 'path' completion as a bare minimum.
+
+Default:
+>
+	let g:mucomplete#scoped_chains = {}
+<
+Example:
+>
+	let g:mucomplete#scoped_chains = {
+		\ 'vim'     : {'vimString':      [],
+		\	       'vimLineComment': ['keyn'],
+		\	       'vimComment':     ['spel']}
+		\ }
 <
 					*'g:mucomplete#completion_delay'*
 Set to a positive value if you want autocompletion to be triggered only when


### PR DESCRIPTION
Allow specific completion chains inside defined syntax element and defined filetypes.

Defining this kind of behaviour with mucomplete#can_complete is awkward, because you should define conditions for all completions that you don't want, rather the ones that you want in a certain syntax element.

Eg, in strings/comments I only want 'keyn' or 'path', with mucomplete#can_complete I would need to define exceptions for all methods (so that they aren't called when syntax is string/comment).

The help section should be clear about how it works.