### PR TITLE
include umlauts for spel/uspl

### DIFF
--- a/autoload/mucomplete.vim
+++ b/autoload/mucomplete.vim
@@ -95,9 +95,9 @@ let g:mucomplete#chains = extend({
       \ 'vim'     : ['path', 'cmd',  'keyn']
       \ }, get(g:, 'mucomplete#chains', {}))
 
-" Regex with special umlaut characters and apostroph (') for spel/uspl completion
+" Regex with special umlaut characters for spel/uspl completion
 fun! mucomplete#get_spel_regex()
-  return '[A-Za-z\u00C0-\u00D6\u00D8-\u00F6\u00F8-\u00FF\u0027]'
+  return '[A-Za-z\u00C0-\u00D6\u00D8-\u00F6\u00F8-\u00FF]'
 endf
 
 " Conditions to be verified for a given method to be applied.

--- a/autoload/mucomplete.vim
+++ b/autoload/mucomplete.vim
@@ -95,6 +95,11 @@ let g:mucomplete#chains = extend({
       \ 'vim'     : ['path', 'cmd',  'keyn']
       \ }, get(g:, 'mucomplete#chains', {}))
 
+" Regex with special umlaut characters and apostroph (') for spel/uspl completion
+fun! mucomplete#get_spel_regex()
+  return '[A-Za-z\u00C0-\u00D6\u00D8-\u00F6\u00F8-\u00FF\u0027]'
+endf
+
 " Conditions to be verified for a given method to be applied.
 if has('lambda')
   if get(g:, 'mucomplete#force_manual', 0)
@@ -141,11 +146,11 @@ if has('lambda')
         \     'omni': s:fm({ t -> strlen(&l:omnifunc) > 0 && s:is_keyword(t) }),
         \     'path': s:fm({ t -> t =~# '\m\%(\%(\f\&[^/\\]\)'.s:pathsep.'\|\%(^\|\s\|\f\|["'']\)'.s:pathsep.'\%(\f\&[^/\\]\|\s\)\+\)$'
         \              || (g:mucomplete_with_key && t =~# '\m\%(\~\|\%(^\|\s\|\f\|["'']\)'.s:pathsep.'\)\%(\f\|\s\)*$') }),
-        \     'spel': s:fm({ t -> &l:spell && !empty(&l:spelllang) && t =~# '\m[A-Za-z\u00C0-\u00D6\u00D8-\u00F6\u00F8-\u00FF]\{3}$' }),
+        \     'spel': s:fm({ t -> &l:spell && !empty(&l:spelllang) && t =~# '\m'.mucomplete#get_spel_regex().'\{3}$' }),
         \     'tags': s:fm({ t -> !empty(tagfiles()) && s:is_keyword(t) }),
         \     'thes': s:fm({ t -> strlen(&l:thesaurus) > 0 && t =~# '\m\a\a\a$' }),
         \     'user': s:fm({ t -> strlen(&l:completefunc) > 0 && s:is_keyword(t) }),
-        \     'uspl': s:fm({ t -> &l:spell && !empty(&l:spelllang) && t =~# '\m[A-Za-z\u00C0-\u00D6\u00D8-\u00F6\u00F8-\u00FF]\{3}$' }),
+        \     'uspl': s:fm({ t -> &l:spell && !empty(&l:spelllang) && t =~# '\m'.mucomplete#get_spel_regex().'\{3}$' }),
         \     'nsnp': s:fm({ t -> get(g:, 'loaded_neosnippet', 0) && s:is_keyword(t) }),
         \     'snip': s:fm({ t -> get(g:, 'loaded_snips', 0) && s:is_keyword(t) }),
         \     'ulti': s:fm({ t -> get(g:, 'did_plugin_ultisnips', 0) && s:is_keyword(t) }),

--- a/autoload/mucomplete.vim
+++ b/autoload/mucomplete.vim
@@ -141,11 +141,11 @@ if has('lambda')
         \     'omni': s:fm({ t -> strlen(&l:omnifunc) > 0 && s:is_keyword(t) }),
         \     'path': s:fm({ t -> t =~# '\m\%(\%(\f\&[^/\\]\)'.s:pathsep.'\|\%(^\|\s\|\f\|["'']\)'.s:pathsep.'\%(\f\&[^/\\]\|\s\)\+\)$'
         \              || (g:mucomplete_with_key && t =~# '\m\%(\~\|\%(^\|\s\|\f\|["'']\)'.s:pathsep.'\)\%(\f\|\s\)*$') }),
-        \     'spel': s:fm({ t -> &l:spell && !empty(&l:spelllang) && t =~# '\m\a\a\a$' }),
+        \     'spel': s:fm({ t -> &l:spell && !empty(&l:spelllang) && t =~# '\m[A-Za-z\u00C0-\u00D6\u00D8-\u00F6\u00F8-\u00FF]\{3}$' }),
         \     'tags': s:fm({ t -> !empty(tagfiles()) && s:is_keyword(t) }),
         \     'thes': s:fm({ t -> strlen(&l:thesaurus) > 0 && t =~# '\m\a\a\a$' }),
         \     'user': s:fm({ t -> strlen(&l:completefunc) > 0 && s:is_keyword(t) }),
-        \     'uspl': s:fm({ t -> &l:spell && !empty(&l:spelllang) && t =~# '\m\a\a\a$' }),
+        \     'uspl': s:fm({ t -> &l:spell && !empty(&l:spelllang) && t =~# '\m[A-Za-z\u00C0-\u00D6\u00D8-\u00F6\u00F8-\u00FF]\{3}$' }),
         \     'nsnp': s:fm({ t -> get(g:, 'loaded_neosnippet', 0) && s:is_keyword(t) }),
         \     'snip': s:fm({ t -> get(g:, 'loaded_snips', 0) && s:is_keyword(t) }),
         \     'ulti': s:fm({ t -> get(g:, 'did_plugin_ultisnips', 0) && s:is_keyword(t) }),

--- a/autoload/mucomplete/compat.vim
+++ b/autoload/mucomplete/compat.vim
@@ -32,7 +32,7 @@ fun! mucomplete#compat#omni(t)
 endf
 
 fun! mucomplete#compat#spel(t)
-  return &l:spell && !empty(&l:spelllang) && a:t =~# '\m\a\a\a$'
+  return &l:spell && !empty(&l:spelllang) && a:t =~# '\m[A-Za-z\u00C0-\u00D6\u00D8-\u00F6\u00F8-\u00FF]\{3}$'
 endf
 
 fun! mucomplete#compat#tags(t)

--- a/autoload/mucomplete/compat.vim
+++ b/autoload/mucomplete/compat.vim
@@ -32,7 +32,7 @@ fun! mucomplete#compat#omni(t)
 endf
 
 fun! mucomplete#compat#spel(t)
-  return &l:spell && !empty(&l:spelllang) && a:t =~# '\m[A-Za-z\u00C0-\u00D6\u00D8-\u00F6\u00F8-\u00FF]\{3}$'
+  return &l:spell && !empty(&l:spelllang) && a:t =~# '\m'.mucomplete#get_spel_regex().'\{3}$'
 endf
 
 fun! mucomplete#compat#tags(t)

--- a/autoload/mucomplete/spel.vim
+++ b/autoload/mucomplete/spel.vim
@@ -7,11 +7,11 @@ set cpo&vim
 
 if exists('*matchstrpos')
   fun! s:getword()
-    return matchstrpos(getline('.'), '[A-Za-z\u00C0-\u00D6\u00D8-\u00F6\u00F8-\u00FF]\+\%'.col('.').'c')
+    return matchstrpos(getline('.'), mucomplete#get_spel_regex().'\+\%'.col('.').'c')
   endf
 else
   fun! s:getword()
-    return [matchstr(getline('.'), '[A-Za-z\u00C0-\u00D6\u00D8-\u00F6\u00F8-\u00FF]\+\%'.col('.').'c'), match(getline('.'), '[A-Za-z\u00C0-\u00D6\u00D8-\u00F6\u00F8-\u00FF]\+\%'.col('.').'c'), 0]
+    return [matchstr(getline('.'), mucomplete#get_spel_regex().'\%'.col('.').'c'), match(getline('.'), mucomplete#get_spel_regex().'\+\%'.col('.').'c'), 0]
   endf
 endif
 

--- a/autoload/mucomplete/spel.vim
+++ b/autoload/mucomplete/spel.vim
@@ -11,7 +11,7 @@ if exists('*matchstrpos')
   endf
 else
   fun! s:getword()
-    return [matchstr(getline('.'), mucomplete#get_spel_regex().'\%'.col('.').'c'), match(getline('.'), mucomplete#get_spel_regex().'\+\%'.col('.').'c'), 0]
+    return [matchstr(getline('.'), mucomplete#get_spel_regex().'\+\%'.col('.').'c'), match(getline('.'), mucomplete#get_spel_regex().'\+\%'.col('.').'c'), 0]
   endf
 endif
 

--- a/autoload/mucomplete/spel.vim
+++ b/autoload/mucomplete/spel.vim
@@ -7,11 +7,11 @@ set cpo&vim
 
 if exists('*matchstrpos')
   fun! s:getword()
-    return matchstrpos(getline('.'), '\w\+\%'.col('.').'c')
+    return matchstrpos(getline('.'), '[A-Za-z\u00C0-\u00D6\u00D8-\u00F6\u00F8-\u00FF]\+\%'.col('.').'c')
   endf
 else
   fun! s:getword()
-    return [matchstr(getline('.'), '\w\+\%'.col('.').'c'), match(getline('.'), '\w\+\%'.col('.').'c'), 0]
+    return [matchstr(getline('.'), '[A-Za-z\u00C0-\u00D6\u00D8-\u00F6\u00F8-\u00FF]\+\%'.col('.').'c'), match(getline('.'), '[A-Za-z\u00C0-\u00D6\u00D8-\u00F6\u00F8-\u00FF]\+\%'.col('.').'c'), 0]
   endf
 endif
 


### PR DESCRIPTION
Umlauts (ä, ö, ü, ß, ...) are not included in the `\w` or `\a` regex.

Most of the time this is no problem, but when completing words from languages that use them, the completion will only register the string after the umlaut, e.g. "Brätwurst" with `spelllang=de` (German) will be seen as "twurst".
When accepting a completion this would then for example give "Bräwurst", which is not correct ("Bratwurst" would be correct).

I have swapped `\w` and `\a` regex for `spel` and `uspl` with `[A-Za-z\u00C0-\u00D6\u00D8-\u00F6\u00F8-\u00FF]`  [(source)](https://www.utf8-chartable.de/unicode-utf8-table.pl) which will include a lot of special umlaut characters for different languages.
