### PR TITLE
Add regex based scoped completion

### DIFF
--- a/autoload/mucomplete.vim
+++ b/autoload/mucomplete.vim
@@ -1,6 +1,7 @@
 " Chained completion that works as I want!
 " Maintainer: Lifepillar <lifepillar@lifepillar.me>
 " License: This file is placed in the public domain
+" vim: et ts=2 sts=2 sw=2
 
 let s:save_cpo = &cpo
 set cpo&vim

--- a/autoload/mucomplete.vim
+++ b/autoload/mucomplete.vim
@@ -315,11 +315,20 @@ endf
 " If the argument is a completion chain (type() returns v:t_list), return it;
 " otherwise, get the completion chain for the current syntax item.
 fun! s:scope_chain(c)
-  return type(a:c) == 3
-        \ ? a:c
-        \ : get(a:c, synIDattr(synID('.', col('.') - 1, 0), 'name'),
-        \       get(a:c, 'default', g:mucomplete#chains['default']))
-endf
+  if type(a:c) ==  v:t_list
+    return a:c
+  else
+    let l:current_syntax = synIDattr(synID('.', col('.') - 1, 0), 'name')
+
+    for l:item in items(a:c)
+      if l:current_syntax =~? l:item[0]
+        return l:item[1]
+      endif
+    endfor
+
+    return get(a:c, 'default', g:mucomplete#chains['default'])
+  endif
+endfun
 
 " Precondition: pumvisible() is false.
 fun! mucomplete#init(dir, tab_completion) " Initialize/reset internal state

--- a/doc/mucomplete.txt
+++ b/doc/mucomplete.txt
@@ -180,8 +180,12 @@ chains may be used. For example:
 >
 	let g:mucomplete#chains = {
 	    \ 'vim': { 'vimString': [],
-	    \          'vimLineComment': ['uspl'],
-	    \          'default': ['path', 'cmd', 'keyn'] }
+	    \		'vimLineComment': ['uspl'],
+	    \		'default': ['path', 'cmd', 'keyn'] },
+	    \ 'rust' : {
+	    \		'default' : ['omni', 'nsnp'],
+	    \		'rustString.*' : [],
+	    \		'rustComment.*' : ['spel'] }
 	    \ }
 <
 The assignment above defines the following behaviour in Vim buffers: no
@@ -190,13 +194,15 @@ completion, Vim commands completion and keyword completion in all other
 places. For all other filetypes, the global default chain is used (a global
 default chain is automatically defined by MUcomplete if it is not provided by
 the user).
+It also define the following in rust buffers : a default chain using omni
+completion and neosnippets, no completion inside strings, and spelling
+completion inside comments (either line or block).
 
-The keys of a scoped chain should be names of filetype-specific highlight
-groups or the `'default'` key. The associated values are standard completion
-chains (i.e., Lists of completion methods). If the `'default'` key is not
-present in a scoped chain, MUcomplete falls back to using the global
-completion chain (that is, the value of |g:mucomplete#chains|`['default']`) if
-necessary.
+The keys of a scoped chain should be regexes mathing highlight groups or the
+`'default'` key. The associated values are standard completion chains (i.e.,
+Lists of completion methods). If the `'default'` key is not present in a
+scoped chain, MUcomplete falls back to using the global completion chain (that
+is, the value of |g:mucomplete#chains|`['default']`) if necessary.
 
 ==============================================================================
 6. Path completion			*mucomplete-path-complete*


### PR DESCRIPTION
This PR adds support for regex based scoped completion, as requested in #174.

Another improvement might be to slightly change the way the chains dict is used, to search in this order :

1.  Scoped chain for this ft
2. Scoped chain in default
3. Default for this ft
4. Default in default

This would allow this kind of configuration :
```vim
let g:mucomplete#chains = {
			\ 'default': {
			\		'default' : ['tags', 'nsnp'],
			\		'.*String.*' : [],
			\		'.*Comment.*' : ['spel']
			\		},
			\ 'rust' :['omni', 'nsnp'],
			\ 'vim' : ['omni', 'nsnp']
			\ }
```

Which would have the same effect as this :
```vim
let g:mucomplete#chains = {
			\ 'default': ['tags', 'nsnp'],
			\ 'rust' : {
			\		"default" : ['omni', 'nsnp'],
			\		"rustString.*" : [],
			\		"rustComment.*" : ['spel'],
			\		},
			\ 'c' : {
			\		"cComment.*" : [],
			\		"cString.*" : []
			\		},
			\ 'vim' : {
			\		'default' : ['omni', 'nsnp'],
			\		'vimComment.*' : [],
			\		'vimString.*' : ['spel']
			\		},
			\ }
```