### PR TITLE
Fix neosnippets errors

### DIFF
--- a/autoload/mucomplete/neosnippet.vim
+++ b/autoload/mucomplete/neosnippet.vim
@@ -6,7 +6,8 @@ let s:save_cpo = &cpo
 set cpo&vim
 
 fun! mucomplete#neosnippet#complete() abort
-  let l:snippets = neosnippet#helpers#get_completion_snippets()
+  let l:snippets = filter(neosnippet#helpers#get_snippets(),
+       \ "!get(v:val.options, 'oneshot', 0)")
   if empty(l:snippets)
     return ''
   endif


### PR DESCRIPTION
After a recent neosnippet change I get many errors when editing any file to the point I have to disable the plugin.

I simply copied the original definition of function `get_completion_snippets` instead of calling that function.
This is the link for the change that cause the issue:

https://github.com/Shougo/neosnippet.vim/commit/5d07842911b485240719b781dfd7817b85c8eb96#diff-21bb063a69b507935e3b22b5a9abee990011263ed266376ff9b1a2b3fedc67eb