### PR TITLE
fix: neovim has default tab mapping now, so override it

### DIFF
--- a/plugin/mucomplete.vim
+++ b/plugin/mucomplete.vim
@@ -23,10 +23,10 @@ endif
 
 if !get(g:, 'mucomplete#no_mappings', get(g:, 'no_plugin_maps', 0))
   if !hasmapto('<plug>(MUcompleteFwd)', 'i')
-    imap <unique> <tab> <plug>(MUcompleteFwd)
+    imap <tab> <plug>(MUcompleteFwd)
   endif
   if !hasmapto('<plug>(MUcompleteBwd)', 'i')
-    imap <unique> <s-tab> <plug>(MUcompleteBwd)
+    imap <s-tab> <plug>(MUcompleteBwd)
   endif
 endif
 


### PR DESCRIPTION
Neovim 0.11 now has a [default mapping](https://neovim.io/doc/user/news-0.11.html#_defaults) for `<Tab>` / `<S-Tab>`. This results in a E227 on loading `vim-mucomplete` per the documentation `:h map-unique`.

I hacked a fix in by simply removing `<unique>` from the `imap` to get it working. However there may be a better way to fix this to support Neovim 0.11.